### PR TITLE
Add support reading victims from the environment

### DIFF
--- a/victims.go
+++ b/victims.go
@@ -2,8 +2,10 @@
 package main
 
 import (
+	"os"
 	"log"
 	"io/ioutil"
+	"strings"
 	"gopkg.in/yaml.v2"
   )
 
@@ -21,15 +23,28 @@ func getVictims() []string {
 
 	// Read File
 	yamlFile, err := ioutil.ReadFile(victimsFile)
-	if err != nil {
-		log.Fatalf("[ERROR] %v", err)
+	if err == nil {
+
+		// Unmarshall Creds
+		err = yaml.Unmarshal(yamlFile, v)
+		if err != nil {
+			log.Fatalf("[ERROR] %v", err)
+		}
+
+	} else {
+
+		// Fall back to using environment variables if no victims.yml file exists
+		envVictims := os.Getenv("VICTIMS")
+		if len(envVictims) > 0 {
+			v.Victims = strings.Split(envVictims, ",")
+		} else {
+			// Fails as if no victims were provided (file or env)
+			log.Fatalf("[ERROR] %v", err)
+		}
+
 	}
 
-	// Unmarshall Creds
-	err = yaml.Unmarshal(yamlFile, v)
-	if err != nil {
-		log.Fatalf("[ERROR] %v", err)
-	}
+
 
 	return v.Victims
 }


### PR DESCRIPTION
Closes #1 

- Used as a fallback when victims.yml file does not exist


**Testing with a log.Println(OK, victims)**
With victims.yml
```
$ VICTIMS=asd,bbxc,ads go run *.go
2021/10/02 13:56:34 OK [A_Chris_Kahuna georgiopizzeria HakaRoland]
```

Without victims.yml
```
$ VICTIMS=asd,bbxc,ads go run *.go
2021/10/02 14:16:10 OK [asd bbxc ads]
```

Without either file or ENV variables
```
VICTIMS= go run *.go
2021/10/02 14:17:57 [ERROR] open victims.yml: no such file or directory
exit status 1
```